### PR TITLE
refactor: use common system proxy options factory

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -16,6 +16,16 @@ authorization server.
 This resource should be able to handle common authorization server from the market by providing a complete
 configuration about the way to apply token introspection.
 
+== Compatibility with APIM
+
+|===
+|Plugin version | APIM version
+
+|2.x and upper                  | 3.18.x to latest
+|1.16.x and upper               | 3.10.x to 3.17.x
+|Up to 1.15.x                   | Up to 3.9.x
+|===
+
 == Configuration
 
 You can configure the resource with the following options :

--- a/pom.xml
+++ b/pom.xml
@@ -36,10 +36,11 @@
 
     <properties>
         <gravitee-bom.version>1.1</gravitee-bom.version>
+        <gravitee-common.version>1.26.1</gravitee-common.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
         <gravitee-gateway-api.version>1.18.1</gravitee-gateway-api.version>
         <gravitee-resource-oauth2-provider-api.version>1.3.0</gravitee-resource-oauth2-provider-api.version>
-        <gravitee-node-api.version>1.4.6</gravitee-node-api.version>
+        <gravitee-node.version>1.23.0</gravitee-node.version>
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/resources</publish-folder-path>
@@ -60,6 +61,13 @@
 
     <dependencies>
         <!-- Gravitee.io API-->
+        <dependency>
+            <groupId>io.gravitee.common</groupId>
+            <artifactId>gravitee-common</artifactId>
+            <version>${gravitee-common.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>io.gravitee.resource</groupId>
             <artifactId>gravitee-resource-api</artifactId>
@@ -84,7 +92,14 @@
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-api</artifactId>
-            <version>${gravitee-node-api.version}</version>
+            <version>${gravitee-node.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-container</artifactId>
+            <version>${gravitee-node.version}</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
BREAKING CHANGE: this version requires APIM in version 3.18 and upper

see https://github.com/gravitee-io/issues/issues/7739
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-7258-feat-use-system-proxy-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-oauth2-provider-generic/2.0.0-7258-feat-use-system-proxy-SNAPSHOT/gravitee-resource-oauth2-provider-generic-2.0.0-7258-feat-use-system-proxy-SNAPSHOT.zip)
  <!-- Version placeholder end -->
