### PR TITLE
fix: add system proxy support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -29,6 +29,12 @@ You can configure the resource with the following options :
 ^.^|string
 ^.^|-
 
+.^|useSystemProxy
+^.^|X
+|TUse system proxy.
+^.^|boolean
+^.^|false
+
 .^|introspectionEndpointMethod
 ^.^|X
 |HTTP method used to introspect the access token.

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
             <version>${gravitee-node-api.version}</version>
             <scope>provided</scope>
         </dependency>
+
         <!-- HTTP client -->
         <dependency>
             <groupId>io.vertx</groupId>

--- a/src/main/java/io/gravitee/resource/oauth2/generic/configuration/OAuth2ResourceConfiguration.java
+++ b/src/main/java/io/gravitee/resource/oauth2/generic/configuration/OAuth2ResourceConfiguration.java
@@ -28,6 +28,8 @@ public class OAuth2ResourceConfiguration implements ResourceConfiguration {
 
     private String introspectionEndpoint;
 
+    private boolean useSystemProxy;
+
     private String introspectionEndpointMethod;
 
     private String userInfoEndpoint;
@@ -74,6 +76,14 @@ public class OAuth2ResourceConfiguration implements ResourceConfiguration {
 
     public void setIntrospectionEndpoint(String introspectionEndpoint) {
         this.introspectionEndpoint = introspectionEndpoint;
+    }
+
+    public boolean isUseSystemProxy() {
+        return useSystemProxy;
+    }
+
+    public void setUseSystemProxy(boolean useSystemProxy) {
+        this.useSystemProxy = useSystemProxy;
     }
 
     public String getIntrospectionEndpointMethod() {

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -14,6 +14,12 @@
       "type" : "string",
       "default": "/oauth/check_token"
     },
+    "useSystemProxy" : {
+      "title": "System proxy",
+      "description": "Use system proxy",
+      "type" : "boolean",
+      "default": false
+    },
     "introspectionEndpointMethod" : {
       "title": "Token introspection method",
       "description": "HTTP method used to introspect the access token.",


### PR DESCRIPTION
The option was missing for generic resource despite being available e.g. for the AM OAuth2 resource.

see https://github.com/gravitee-io/issues/issues/7258

Note this fix is intended to target our support branch, and not introduce breaking changes between minor versions.

The common proxy options factory refactoring will be introduced with APIM 3.18.x