### PR TITLE
Handle customer userClaim

### DIFF
--- a/src/main/java/io/gravitee/resource/oauth2/generic/OAuth2GenericResource.java
+++ b/src/main/java/io/gravitee/resource/oauth2/generic/OAuth2GenericResource.java
@@ -374,6 +374,14 @@ public class OAuth2GenericResource extends OAuth2Resource<OAuth2ResourceConfigur
     }
 
     @Override
+    public String getUserClaim() {
+        if (configuration().getUserClaim() != null && !configuration().getUserClaim().isEmpty()) {
+            return configuration().getUserClaim();
+        }
+        return super.getUserClaim();
+    }
+
+    @Override
     public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
         this.applicationContext = applicationContext;
     }

--- a/src/test/java/io/gravitee/resource/oauth2/generic/OAuth2GenericResourceTest.java
+++ b/src/test/java/io/gravitee/resource/oauth2/generic/OAuth2GenericResourceTest.java
@@ -23,6 +23,7 @@ import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.node.api.Node;
+import io.gravitee.resource.oauth2.api.OAuth2Resource;
 import io.gravitee.resource.oauth2.generic.configuration.OAuth2ResourceConfiguration;
 import io.vertx.core.Vertx;
 import java.util.concurrent.CountDownLatch;
@@ -303,5 +304,16 @@ public class OAuth2GenericResourceTest {
         );
 
         Assert.assertEquals(true, lock.await(10000, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void shouldGetCustomUserClaim() {
+        Mockito.when(configuration.getUserClaim()).thenReturn("customUserClaim");
+        Assert.assertEquals("customUserClaim", resource.getUserClaim());
+    }
+
+    @Test
+    public void shouldGetDefaultUserClaim() {
+        Assert.assertEquals("sub", resource.getUserClaim());
     }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-2453

**Description**

UserClaim can be configured in the form, but the custom value is never used to read the oauth payload.

_NB: for OAuth2AMResource, there is no bug. The userClaim field is indeed read from the configuration._
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.1-apim-2453-handle-userclaim-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-oauth2-provider-generic/2.0.1-apim-2453-handle-userclaim-SNAPSHOT/gravitee-resource-oauth2-provider-generic-2.0.1-apim-2453-handle-userclaim-SNAPSHOT.zip)
  <!-- Version placeholder end -->
