### PR TITLE
feat: rework schema-form to use new GioJsonSchema Ui component

### DIFF
--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -5,3 +5,4 @@ description=${project.description}
 class=io.gravitee.resource.oauth2.generic.OAuth2GenericResource
 type=resource
 icon=oauth2.svg
+category=OAuth2

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,6 +1,6 @@
 {
   "type" : "object",
-  "id" : "urn:jsonschema:io:gravitee:resource:oauth2:generic:configuration:OAuth2ResourceConfiguration",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "properties" : {
     "authorizationServerUrl": {
       "title": "Authorization server URL",
@@ -61,9 +61,7 @@
       "title": "Client Secret",
       "description": "The client secret used for token introspection.",
       "type" : "string",
-      "x-schema-form": {
-        "type": "password"
-      }
+        "format": "password"
     },
     "useClientAuthorizationHeader": {
       "title": "Use HTTP header for client authorization",


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-2212

**Description**

A small description of what you did in that PR.

**Additional context**

https://github.com/gravitee-io/gravitee-resource-oauth2-provider-generic/assets/4974420/e0d7de69-a0ef-442b-a9c5-03e0e2238c3f



<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.0-APIM-2364-json-schema-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-oauth2-provider-generic/2.1.0-APIM-2364-json-schema-SNAPSHOT/gravitee-resource-oauth2-provider-generic-2.1.0-APIM-2364-json-schema-SNAPSHOT.zip)
  <!-- Version placeholder end -->
