### PR TITLE
fix: add clientId as a secret value, fix README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -21,8 +21,9 @@ configuration about the way to apply token introspection.
 |===
 |Plugin version | APIM version
 
-|3.0 and upper                  | 4.4.x to latest
-|2.0 and upper                  | 3.18.x to 4.3.X
+|4.0 and upper                  | 4.6.x to latest
+|3.0 and upper                  | 4.4.x to 4.5.x
+|2.0 and upper                  | 3.18.x to 4.3.x
 |1.16.x and upper               | 3.10.x to 3.17.x
 |Up to 1.15.x                   | Up to 3.9.x
 |===
@@ -32,12 +33,14 @@ configuration about the way to apply token introspection.
 You can configure the resource with the following options :
 
 |===
-|Property |Required |Description |Type |Default
+|Property |Required |Description |Type |Default | Support EL | Support Secret
 
 .^|introspectionEndpoint
 ^.^|X
 |The URL which is used by the resource to introspect an incoming access token.
 ^.^|string
+^.^|-
+^.^|X
 ^.^|-
 
 .^|useSystemProxy
@@ -45,65 +48,87 @@ You can configure the resource with the following options :
 |TUse system proxy.
 ^.^|boolean
 ^.^|false
+^.^|X
+^.^|-
 
 .^|introspectionEndpointMethod
 ^.^|X
 |HTTP method used to introspect the access token.
 ^.^|HTTP Method
 ^.^|GET
+^.^|X
+^.^|-
 
 .^|clientId
 ^.^|X
 |The client identifier.
 ^.^|string
 ^.^|-
+^.^|X
+^.^|X
 
 .^|clientSecret
 ^.^|X
 |The client secret.
 ^.^|string
 ^.^|-
+^.^|X
+^.^|X
 
 .^|useClientAuthorizationHeader
 ^.^|-
 |To prevent token scanning attacks, the endpoint MUST also require some form of authorization to access this endpoint. In this case we are using an HTTP header for client authentication.
 ^.^|boolean
 ^.^|true
+^.^|X
+^.^|-
 
 .^|clientAuthorizationHeaderName
 ^.^|-
 |Authorization header.
 ^.^|string
 ^.^|Authorization
+^.^|X
+^.^|-
 
 .^|clientAuthorizationHeaderScheme
 ^.^|-
 |Authorization scheme.
 ^.^|string
 ^.^|Basic
+^.^|X
+^.^|-
 
 .^|tokenIsSuppliedByQueryParam
 ^.^|-
 |Access token is passed to the introspection endpoint using a query parameter.
 ^.^|boolean
 ^.^|true
+^.^|X
+^.^|-
 
 .^|tokenQueryParamName
 ^.^|-
 |Query parameter used to supply access token.
 ^.^|string
 ^.^|token
+^.^|X
+^.^|-
 
 .^|tokenIsSuppliedByHttpHeader
 ^.^|-
 |Access token is passed to the introspection endpoint using an HTTP header.
 ^.^|boolean
 ^.^|false
+^.^|X
+^.^|-
 
 .^|tokenHeaderName
 ^.^|-
 |HTTP header used to supply access token.
 ^.^|string
+^.^|-
+^.^|X
 ^.^|-
 
 |===
@@ -125,5 +150,18 @@ You can configure the resource with the following options :
         "tokenQueryParamName": "token",
         "useClientAuthorizationHeader": true
     }
+}
+----
+
+
+[source, json]
+.Extract with a secret and EL
+----
+{
+  "configuration": {
+        "introspectionEndpoint": "https://{#dictionary['oauth']['host']/oauth/check_token",
+        "clientId": "my-client",
+        "clientSecret": "f2ddb55e-30b5-4a45-9db5-5e30b52a4574",
+  }
 }
 ----

--- a/src/main/java/io/gravitee/resource/oauth2/generic/configuration/OAuth2ResourceConfiguration.java
+++ b/src/main/java/io/gravitee/resource/oauth2/generic/configuration/OAuth2ResourceConfiguration.java
@@ -39,6 +39,8 @@ public class OAuth2ResourceConfiguration implements ResourceConfiguration {
 
     private String userInfoEndpoint;
     private String userInfoEndpointMethod;
+
+    @Secret
     private String clientId;
 
     @Secret

--- a/src/test/java/io/gravitee/resource/oauth2/generic/OAuth2GenericResourceConfigurationTest.java
+++ b/src/test/java/io/gravitee/resource/oauth2/generic/OAuth2GenericResourceConfigurationTest.java
@@ -85,14 +85,19 @@ class OAuth2GenericResourceConfigurationTest {
     void should_eval_config() throws Exception {
         OAuth2ResourceConfiguration config = new OAuth2ResourceConfiguration();
         config.setAuthorizationServerUrl("http://localhost:8080/auth");
+        config.setClientId(asSecretEL("that is an ID"));
         config.setClientSecret(asSecretEL("that is a secret"));
         OAuth2GenericResource oAuth2GenericResource = underTest(config);
         oAuth2GenericResource.start();
 
+        assertThat(oAuth2GenericResource.configuration().getClientId()).isEqualTo("that is an ID");
         assertThat(oAuth2GenericResource.configuration().getClientSecret()).isEqualTo("that is a secret");
 
         assertThat(recordedSecretFieldAccessControls)
-            .containsExactlyInAnyOrder(new SecretFieldAccessControl(true, FieldKind.GENERIC, "clientSecret"));
+            .containsExactlyInAnyOrder(
+                new SecretFieldAccessControl(true, FieldKind.GENERIC, "clientSecret"),
+                new SecretFieldAccessControl(true, FieldKind.GENERIC, "clientId")
+            );
     }
 
     @Test


### PR DESCRIPTION
**Issue**

Update readme with latest compatibility matrix
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.1-update-readme-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-oauth2-provider-generic/4.0.1-update-readme-SNAPSHOT/gravitee-resource-oauth2-provider-generic-4.0.1-update-readme-SNAPSHOT.zip)
  <!-- Version placeholder end -->
