### PR TITLE
fix: include the scopes when returning the protected resource metadata from the oauth2 policy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,9 @@
         <dependency>
             <groupId>io.gravitee.resource</groupId>
             <artifactId>gravitee-resource-oauth2-provider-api</artifactId>
-            <scope>provided</scope>
+            <!-- Version specified to avoid a breaking change. Once the versions of APIM under 4.12 will not be maintained anymore
+                    we can move back to scope provided and remove the version. -->
+            <version>1.5.1</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/io/gravitee/resource/oauth2/generic/OAuth2GenericResource.java
+++ b/src/main/java/io/gravitee/resource/oauth2/generic/OAuth2GenericResource.java
@@ -347,11 +347,15 @@ public class OAuth2GenericResource extends OAuth2Resource<OAuth2ResourceConfigur
     }
 
     @Override
-    public OAuth2ResourceMetadata getProtectedResourceMetadata(String protectedResourceUri) {
+    public OAuth2ResourceMetadata getProtectedResourceMetadata(String protectedResourceUri, List<String> scopesSupported) {
         String authServerMetadataEndpoint = configuration.getAuthorizationServerMetadataEndpoint();
         String authServerEndpoint = authServerMetadataEndpoint.substring(0, authServerMetadataEndpoint.lastIndexOf("/.well-known/"));
         URI authServerUri = URI.create(configuration.getAuthorizationServerUrl() + authServerEndpoint);
         String authorizationServer = authServerUri.normalize().toString();
-        return new OAuth2ResourceMetadata(protectedResourceUri, List.of(authorizationServer), List.of());
+        return new OAuth2ResourceMetadata(
+            protectedResourceUri,
+            List.of(authorizationServer),
+            scopesSupported != null ? scopesSupported : List.of()
+        );
     }
 }

--- a/src/test/java/io/gravitee/resource/oauth2/generic/OAuth2GenericResourceTest.java
+++ b/src/test/java/io/gravitee/resource/oauth2/generic/OAuth2GenericResourceTest.java
@@ -36,6 +36,7 @@ import io.gravitee.resource.oauth2.generic.configuration.OAuth2ResourceConfigura
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.vertx.rxjava3.core.Vertx;
 import java.lang.reflect.Field;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.awaitility.Awaitility;
@@ -324,12 +325,30 @@ class OAuth2GenericResourceTest {
         configuration.setAuthorizationServerMetadataEndpoint("/realms/myrealm/.well-known/oauth-authorization-server");
         configuration.setAuthorizationServerUrl(authorizationServerUrl);
         resource.setConfiguration(configuration);
-        OAuth2ResourceMetadata resourceMetadata = resource.getProtectedResourceMetadata("https://backend.com");
+        OAuth2ResourceMetadata resourceMetadata = resource.getProtectedResourceMetadata("https://backend.com", List.of());
         assertAll(
             () -> assertThat(resourceMetadata.protectedResourceUri()).isEqualTo("https://backend.com"),
             () -> assertThat(resourceMetadata.authorizationServers().get(0)).isEqualTo("https://some.keycloak.com/realms/myrealm"),
             () -> assertThat(resourceMetadata.authorizationServers().size()).isEqualTo(1),
             () -> assertThat(resourceMetadata.scopesSupported()).isEmpty()
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "https://some.keycloak.com", "https://some.keycloak.com/" })
+    void testGetProtectedResourceMetadata_with_scopes_supported(String authorizationServerUrl) {
+        OAuth2GenericResource resource = new OAuth2GenericResource();
+        OAuth2ResourceConfiguration configuration = new OAuth2ResourceConfiguration();
+        configuration.setAuthorizationServerMetadataEndpoint("/realms/myrealm/.well-known/oauth-authorization-server");
+        configuration.setAuthorizationServerUrl(authorizationServerUrl);
+        resource.setConfiguration(configuration);
+        List<String> scopesSupported = List.of("read", "write", "admin");
+        OAuth2ResourceMetadata resourceMetadata = resource.getProtectedResourceMetadata("https://backend.com", scopesSupported);
+        assertAll(
+            () -> assertThat(resourceMetadata.protectedResourceUri()).isEqualTo("https://backend.com"),
+            () -> assertThat(resourceMetadata.authorizationServers().get(0)).isEqualTo("https://some.keycloak.com/realms/myrealm"),
+            () -> assertThat(resourceMetadata.authorizationServers().size()).isEqualTo(1),
+            () -> assertThat(resourceMetadata.scopesSupported()).containsExactly("read", "write", "admin")
         );
     }
 }


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-13671
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.1-apim-13671-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-oauth2-provider-generic/5.0.1-apim-13671-SNAPSHOT/gravitee-resource-oauth2-provider-generic-5.0.1-apim-13671-SNAPSHOT.zip)
  <!-- Version placeholder end -->
