### PR TITLE
Aiam 113 token exchange support

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,46 @@
+#
+# Copyright © 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version: "3"
+
+env:
+    APIM_GW_DISTRIBUTION_PATH: "{{.APIM_GW_DISTRIBUTION_PATH }}"
+    APIM_MAPI_DISTRIBUTION_PATH: "{{.APIM_MAPI_DISTRIBUTION_PATH }}"
+
+tasks:
+    build:
+        desc: "Build"
+        cmds:
+            - mvn clean install -DskipTests -Dskip.validation
+
+    copy:
+        desc: "Copy resource"
+        cmds:
+            - cp target/gravitee-resource-oauth2-provider-generic-*.zip ${APIM_GW_DISTRIBUTION_PATH}/plugins
+            - cp target/gravitee-resource-oauth2-provider-generic-*.zip ${APIM_MAPI_DISTRIBUTION_PATH}/plugins
+
+    clean:
+        desc: "Clean"
+        cmds:
+            - rm -f ${APIM_GW_DISTRIBUTION_PATH}/plugins/gravitee-resource-oauth2-provider-generic-*.zip
+            - rm -f ${APIM_MAPI_DISTRIBUTION_PATH}/plugins/gravitee-resource-oauth2-provider-generic-*.zip
+
+    all:
+        desc: "Clean, Build and copy"
+        cmds:
+            - task: clean
+            - task: build
+            - task: copy

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,10 @@
         <dependency>
             <groupId>io.gravitee.resource</groupId>
             <artifactId>gravitee-resource-oauth2-provider-api</artifactId>
-            <scope>provided</scope>
+            <!-- Version pinned (instead of provided scope) so the plugin bundles the token-exchange-capable
+                 resource API and can run on APIM versions that still provide an older one. Move back to
+                 provided scope once all maintained APIM versions ship resource API >= 1.6.0. -->
+            <version>1.6.0-token-exchange-support-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/io/gravitee/resource/oauth2/generic/OAuth2GenericResource.java
+++ b/src/main/java/io/gravitee/resource/oauth2/generic/OAuth2GenericResource.java
@@ -38,6 +38,8 @@ import io.gravitee.resource.oauth2.api.OAuth2ResourceException;
 import io.gravitee.resource.oauth2.api.OAuth2ResourceMetadata;
 import io.gravitee.resource.oauth2.api.OAuth2Response;
 import io.gravitee.resource.oauth2.api.openid.UserInfoResponse;
+import io.gravitee.resource.oauth2.api.tokenexchange.TokenExchangeRequest;
+import io.gravitee.resource.oauth2.api.tokenexchange.TokenExchangeResponse;
 import io.gravitee.resource.oauth2.generic.configuration.OAuth2ResourceConfiguration;
 import io.gravitee.resource.oauth2.generic.configuration.OAuth2ResourceConfigurationEvaluator;
 import io.vertx.core.Vertx;
@@ -45,12 +47,16 @@ import io.vertx.core.http.*;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import javax.inject.Inject;
 import lombok.AccessLevel;
 import lombok.Setter;
@@ -69,6 +75,9 @@ public class OAuth2GenericResource extends OAuth2Resource<OAuth2ResourceConfigur
 
     public static final String ERROR_CHECKING_OAUTH_2_TOKEN = "An error occurs while checking OAuth2 token";
     public static final String ERROR_GETTING_USERINFO = "An error occurs while getting userinfo from access token";
+    public static final String ERROR_EXCHANGING_TOKEN = "An error occurs while exchanging token";
+
+    private static final String TOKEN_EXCHANGE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange";
     private final Logger logger = LoggerFactory.getLogger(OAuth2GenericResource.class);
 
     // Pattern reuse for duplicate slash removal
@@ -89,6 +98,8 @@ public class OAuth2GenericResource extends OAuth2Resource<OAuth2ResourceConfigur
     private String introspectionEndpointURI;
 
     private String userInfoEndpointURI;
+
+    private String tokenExchangeEndpointURL;
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -156,6 +167,11 @@ public class OAuth2GenericResource extends OAuth2Resource<OAuth2ResourceConfigur
             authorizationServerPort,
             authorizationServerUrl.toURL().getFile()
         );
+
+        String tokenExchangeEndpoint = configuration().getTokenExchangeEndpoint();
+        if (tokenExchangeEndpoint != null && !tokenExchangeEndpoint.isBlank()) {
+            tokenExchangeEndpointURL = tokenExchangeEndpoint.trim();
+        }
 
         httpClient = VertxHttpClientFactory.builder()
             .vertx(applicationContext.getBean(io.vertx.rxjava3.core.Vertx.class))
@@ -325,6 +341,152 @@ public class OAuth2GenericResource extends OAuth2Resource<OAuth2ResourceConfigur
                     });
                 request.end();
             });
+    }
+
+    @Override
+    public void tokenExchange(TokenExchangeRequest tokenExchangeRequest, Handler<TokenExchangeResponse> responseHandler) {
+        if (tokenExchangeEndpointURL == null) {
+            responseHandler.handle(new TokenExchangeResponse(new OAuth2ResourceException("tokenExchangeEndpoint is not configured")));
+            return;
+        }
+
+        if (tokenExchangeRequest == null) {
+            responseHandler.handle(new TokenExchangeResponse(new IllegalArgumentException("tokenExchangeRequest cannot be null")));
+            return;
+        }
+
+        if (tokenExchangeRequest.getSubjectToken() == null || tokenExchangeRequest.getSubjectToken().isBlank()) {
+            responseHandler.handle(new TokenExchangeResponse(new IllegalArgumentException("subject_token is required")));
+            return;
+        }
+
+        if (tokenExchangeRequest.getSubjectTokenType() == null || tokenExchangeRequest.getSubjectTokenType().isBlank()) {
+            responseHandler.handle(new TokenExchangeResponse(new IllegalArgumentException("subject_token_type is required")));
+            return;
+        }
+
+        logger.debug("Exchange token by requesting {}", tokenExchangeEndpointURL);
+
+        final RequestOptions reqOptions = new RequestOptions()
+            .setMethod(HttpMethod.POST)
+            .setAbsoluteURI(tokenExchangeEndpointURL)
+            .putHeader(HttpHeaderNames.USER_AGENT, userAgent)
+            .putHeader("X-Gravitee-Request-Id", UUID.toString(UUID.random()))
+            .putHeader(HttpHeaderNames.ACCEPT, MediaType.APPLICATION_JSON)
+            .putHeader(HttpHeaderNames.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED);
+
+        Map<String, String> form = new LinkedHashMap<>();
+        form.put("grant_type", TOKEN_EXCHANGE_GRANT_TYPE);
+        form.put("subject_token", tokenExchangeRequest.getSubjectToken());
+        form.put("subject_token_type", tokenExchangeRequest.getSubjectTokenType());
+        putIfPresent(form, "resource", tokenExchangeRequest.getResource());
+        putIfPresent(form, "audience", tokenExchangeRequest.getAudience());
+        putIfPresent(form, "scope", tokenExchangeRequest.getScope());
+        putIfPresent(form, "requested_token_type", tokenExchangeRequest.getRequestedTokenType());
+        putIfPresent(form, "actor_token", tokenExchangeRequest.getActorToken());
+        putIfPresent(form, "actor_token_type", tokenExchangeRequest.getActorTokenType());
+
+        String clientId = configuration().getClientId();
+        String clientSecret = configuration().getClientSecret();
+        boolean hasClientCredentials = clientId != null && !clientId.isBlank() && clientSecret != null && !clientSecret.isBlank();
+
+        if (hasClientCredentials) {
+            if (configuration().isUseClientAuthorizationHeader()) {
+                String authorizationHeader = configuration.getClientAuthorizationHeaderName();
+                String authorizationValue =
+                    configuration.getClientAuthorizationHeaderScheme().trim() +
+                    AUTHORIZATION_HEADER_SCHEME_SEPARATOR +
+                    Base64.getEncoder().encodeToString(
+                        (clientId + AUTHORIZATION_HEADER_VALUE_BASE64_SEPARATOR + clientSecret).getBytes(StandardCharsets.UTF_8)
+                    );
+                reqOptions.putHeader(authorizationHeader, authorizationValue);
+            } else {
+                form.put("client_id", clientId);
+                form.put("client_secret", clientSecret);
+            }
+        }
+
+        String body = form
+            .entrySet()
+            .stream()
+            .map(
+                entry ->
+                    URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8) +
+                    '=' +
+                    URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8)
+            )
+            .collect(Collectors.joining("&"));
+
+        httpClient
+            .request(reqOptions)
+            .onFailure(event -> {
+                logger.error(ERROR_EXCHANGING_TOKEN, event);
+                responseHandler.handle(new TokenExchangeResponse(event));
+            })
+            .onSuccess(request -> {
+                request
+                    .response()
+                    .onComplete(asyncResponse -> {
+                        if (asyncResponse.failed()) {
+                            logger.error(ERROR_EXCHANGING_TOKEN, asyncResponse.cause());
+                            responseHandler.handle(new TokenExchangeResponse(asyncResponse.cause()));
+                        } else {
+                            final HttpClientResponse response = asyncResponse.result();
+                            response.bodyHandler(buffer -> {
+                                logger.debug("Token exchange endpoint returns a response with a {} status code", response.statusCode());
+
+                                if (response.statusCode() == HttpStatusCode.OK_200) {
+                                    handleTokenExchangeSuccess(buffer.toString(), responseHandler);
+                                } else {
+                                    logger.error(
+                                        "An error occurs while exchanging token. Request ends with status {}: {}",
+                                        response.statusCode(),
+                                        buffer
+                                    );
+                                    responseHandler.handle(new TokenExchangeResponse(new OAuth2ResourceException(ERROR_EXCHANGING_TOKEN)));
+                                }
+                            });
+                        }
+                    });
+                request.end(body);
+            });
+    }
+
+    private void handleTokenExchangeSuccess(String body, Handler<TokenExchangeResponse> responseHandler) {
+        try {
+            JsonNode payload = MAPPER.readTree(body);
+            String accessToken = payload.path("access_token").asText(null);
+            if (accessToken == null) {
+                responseHandler.handle(
+                    new TokenExchangeResponse(new OAuth2ResourceException("Token exchange response does not contain an access_token"))
+                );
+                return;
+            }
+            TokenExchangeResponse.Builder responseBuilder = TokenExchangeResponse.builder(
+                accessToken,
+                payload.path("issued_token_type").asText(null),
+                payload.path("token_type").asText(null)
+            );
+            if (payload.hasNonNull("expires_in")) {
+                responseBuilder.expiresIn(payload.path("expires_in").asLong());
+            }
+            if (payload.hasNonNull("scope")) {
+                responseBuilder.scope(payload.path("scope").asText());
+            }
+            if (payload.hasNonNull("refresh_token")) {
+                responseBuilder.refreshToken(payload.path("refresh_token").asText());
+            }
+            responseHandler.handle(responseBuilder.build());
+        } catch (IOException e) {
+            logger.error("Unable to parse token exchange response: {}", body, e);
+            responseHandler.handle(new TokenExchangeResponse(e));
+        }
+    }
+
+    private static void putIfPresent(Map<String, String> form, String key, String value) {
+        if (value != null && !value.isBlank()) {
+            form.put(key, value);
+        }
     }
 
     @Override

--- a/src/main/java/io/gravitee/resource/oauth2/generic/configuration/OAuth2ResourceConfiguration.java
+++ b/src/main/java/io/gravitee/resource/oauth2/generic/configuration/OAuth2ResourceConfiguration.java
@@ -39,6 +39,7 @@ public class OAuth2ResourceConfiguration implements ResourceConfiguration {
     private String authorizationServerUrl;
     private String introspectionEndpoint;
     private String authorizationServerMetadataEndpoint;
+    private String tokenExchangeEndpoint;
 
     @Setter(AccessLevel.NONE)
     private boolean useSystemProxy;

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -27,6 +27,11 @@
             "enum": ["GET", "POST"],
             "default": "GET"
         },
+        "tokenExchangeEndpoint": {
+            "title": "Token exchange endpoint",
+            "description": "Full URL of the OAuth 2.0 Token Exchange endpoint (RFC 8693). Supports EL",
+            "type": "string"
+        },
         "scopeSeparator": {
             "title": "Scope separator",
             "description": "Separator used to separate scopes for token introspection (default is a whitespace)",

--- a/src/test/java/io/gravitee/resource/oauth2/generic/OAuth2GenericResourceTest.java
+++ b/src/test/java/io/gravitee/resource/oauth2/generic/OAuth2GenericResourceTest.java
@@ -32,13 +32,18 @@ import io.gravitee.plugin.configurations.http.HttpProxyOptions;
 import io.gravitee.plugin.configurations.ssl.SslOptions;
 import io.gravitee.resource.api.AbstractConfigurableResource;
 import io.gravitee.resource.oauth2.api.OAuth2ResourceMetadata;
+import io.gravitee.resource.oauth2.api.tokenexchange.TokenExchangeRequest;
+import io.gravitee.resource.oauth2.api.tokenexchange.TokenExchangeResponse;
 import io.gravitee.resource.oauth2.generic.configuration.OAuth2ResourceConfiguration;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.vertx.rxjava3.core.Vertx;
 import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -349,6 +354,168 @@ class OAuth2GenericResourceTest {
             () -> assertThat(resourceMetadata.authorizationServers().get(0)).isEqualTo("https://some.keycloak.com/realms/myrealm"),
             () -> assertThat(resourceMetadata.authorizationServers().size()).isEqualTo(1),
             () -> assertThat(resourceMetadata.scopesSupported()).containsExactly("read", "write", "admin")
+        );
+    }
+
+    @Test
+    void should_exchange_token_with_basic_client_authentication(WireMockRuntimeInfo wireMockRuntimeInfo) throws Exception {
+        stubFor(
+            post(urlEqualTo("/oauth/token")).willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withBody(
+                        "{\"access_token\": \"exchanged-token\", \"issued_token_type\": \"urn:ietf:params:oauth:token-type:access_token\", \"token_type\": \"Bearer\", \"expires_in\": 3600, \"scope\": \"read\"}"
+                    )
+            )
+        );
+
+        configuration.setIntrospectionEndpoint("http://localhost:" + wireMockRuntimeInfo.getHttpPort() + "/oauth/introspect");
+        configuration.setIntrospectionEndpointMethod(HttpMethod.POST.name());
+        configuration.setTokenExchangeEndpoint("http://localhost:" + wireMockRuntimeInfo.getHttpPort() + "/oauth/token");
+        configuration.setClientId("my-client");
+        configuration.setClientSecret("my-secret");
+        configuration.setUseClientAuthorizationHeader(true);
+        configuration.setClientAuthorizationHeaderName("Authorization");
+        configuration.setClientAuthorizationHeaderScheme("Basic");
+
+        resource.doStart();
+
+        AtomicReference<TokenExchangeResponse> result = new AtomicReference<>();
+        resource.tokenExchange(
+            TokenExchangeRequest.builder("subject-token", TokenExchangeRequest.TOKEN_TYPE_ACCESS_TOKEN).audience("upstream-mcp").build(),
+            result::set
+        );
+
+        Awaitility.await()
+            .atMost(10, TimeUnit.SECONDS)
+            .until(() -> result.get() != null);
+
+        assertAll(
+            () -> assertThat(result.get().isSuccess()).isTrue(),
+            () -> assertThat(result.get().getAccessToken()).isEqualTo("exchanged-token"),
+            () -> assertThat(result.get().getIssuedTokenType()).isEqualTo("urn:ietf:params:oauth:token-type:access_token"),
+            () -> assertThat(result.get().getTokenType()).isEqualTo("Bearer"),
+            () -> assertThat(result.get().getExpiresIn()).isEqualTo(3600L),
+            () -> assertThat(result.get().getScope()).isEqualTo("read")
+        );
+
+        verify(
+            postRequestedFor(urlPathEqualTo("/oauth/token"))
+                .withHeader(
+                    "Authorization",
+                    equalTo("Basic " + Base64.getEncoder().encodeToString("my-client:my-secret".getBytes(StandardCharsets.UTF_8)))
+                )
+                .withRequestBody(containing("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange"))
+                .withRequestBody(containing("subject_token=subject-token"))
+                .withRequestBody(containing("subject_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aaccess_token"))
+                .withRequestBody(containing("audience=upstream-mcp"))
+        );
+    }
+
+    @Test
+    void should_exchange_token_with_client_credentials_in_body(WireMockRuntimeInfo wireMockRuntimeInfo) throws Exception {
+        stubFor(
+            post(urlEqualTo("/oauth/token")).willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withBody(
+                        "{\"access_token\": \"exchanged-token\", \"issued_token_type\": \"urn:ietf:params:oauth:token-type:access_token\", \"token_type\": \"Bearer\"}"
+                    )
+            )
+        );
+
+        configuration.setIntrospectionEndpoint("http://localhost:" + wireMockRuntimeInfo.getHttpPort() + "/oauth/introspect");
+        configuration.setIntrospectionEndpointMethod(HttpMethod.POST.name());
+        configuration.setTokenExchangeEndpoint("http://localhost:" + wireMockRuntimeInfo.getHttpPort() + "/oauth/token");
+        configuration.setClientId("my-client");
+        configuration.setClientSecret("my-secret");
+        configuration.setUseClientAuthorizationHeader(false);
+
+        resource.doStart();
+
+        AtomicReference<TokenExchangeResponse> result = new AtomicReference<>();
+        resource.tokenExchange(
+            TokenExchangeRequest.builder("subject-token", TokenExchangeRequest.TOKEN_TYPE_ACCESS_TOKEN).build(),
+            result::set
+        );
+
+        Awaitility.await()
+            .atMost(10, TimeUnit.SECONDS)
+            .until(() -> result.get() != null);
+
+        assertThat(result.get().isSuccess()).isTrue();
+
+        verify(
+            postRequestedFor(urlPathEqualTo("/oauth/token"))
+                .withRequestBody(containing("client_id=my-client"))
+                .withRequestBody(containing("client_secret=my-secret"))
+        );
+    }
+
+    @Test
+    void should_fail_token_exchange_when_endpoint_returns_an_error(WireMockRuntimeInfo wireMockRuntimeInfo) throws Exception {
+        stubFor(post(urlEqualTo("/oauth/token")).willReturn(aResponse().withStatus(400).withBody("{\"error\": \"invalid_grant\"}")));
+
+        configuration.setIntrospectionEndpoint("http://localhost:" + wireMockRuntimeInfo.getHttpPort() + "/oauth/introspect");
+        configuration.setIntrospectionEndpointMethod(HttpMethod.POST.name());
+        configuration.setTokenExchangeEndpoint("http://localhost:" + wireMockRuntimeInfo.getHttpPort() + "/oauth/token");
+
+        resource.doStart();
+
+        AtomicReference<TokenExchangeResponse> result = new AtomicReference<>();
+        resource.tokenExchange(
+            TokenExchangeRequest.builder("subject-token", TokenExchangeRequest.TOKEN_TYPE_ACCESS_TOKEN).build(),
+            result::set
+        );
+
+        Awaitility.await()
+            .atMost(10, TimeUnit.SECONDS)
+            .until(() -> result.get() != null);
+
+        assertAll(() -> assertThat(result.get().isSuccess()).isFalse(), () -> assertThat(result.get().getThrowable()).isNotNull());
+    }
+
+    @Test
+    void should_fail_token_exchange_when_subject_token_is_missing(WireMockRuntimeInfo wireMockRuntimeInfo) throws Exception {
+        configuration.setIntrospectionEndpoint("http://localhost:" + wireMockRuntimeInfo.getHttpPort() + "/oauth/introspect");
+        configuration.setIntrospectionEndpointMethod(HttpMethod.POST.name());
+        configuration.setTokenExchangeEndpoint("http://localhost:" + wireMockRuntimeInfo.getHttpPort() + "/oauth/token");
+
+        resource.doStart();
+
+        AtomicReference<TokenExchangeResponse> result = new AtomicReference<>();
+        resource.tokenExchange(TokenExchangeRequest.builder(null, TokenExchangeRequest.TOKEN_TYPE_ACCESS_TOKEN).build(), result::set);
+
+        Awaitility.await()
+            .atMost(10, TimeUnit.SECONDS)
+            .until(() -> result.get() != null);
+
+        assertAll(
+            () -> assertThat(result.get().isSuccess()).isFalse(),
+            () -> assertThat(result.get().getThrowable()).hasMessageContaining("subject_token is required")
+        );
+    }
+
+    @Test
+    void should_fail_token_exchange_when_token_endpoint_is_not_configured(WireMockRuntimeInfo wireMockRuntimeInfo) throws Exception {
+        configuration.setIntrospectionEndpoint("http://localhost:" + wireMockRuntimeInfo.getHttpPort() + "/oauth/introspect");
+        configuration.setIntrospectionEndpointMethod(HttpMethod.POST.name());
+
+        resource.doStart();
+
+        AtomicReference<TokenExchangeResponse> result = new AtomicReference<>();
+        resource.tokenExchange(
+            TokenExchangeRequest.builder("subject-token", TokenExchangeRequest.TOKEN_TYPE_ACCESS_TOKEN).build(),
+            result::set
+        );
+
+        Awaitility.await()
+            .atMost(10, TimeUnit.SECONDS)
+            .until(() -> result.get() != null);
+
+        assertAll(
+            () -> assertThat(result.get().isSuccess()).isFalse(),
+            () -> assertThat(result.get().getThrowable()).hasMessageContaining("tokenExchangeEndpoint is not configured")
         );
     }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/AIAM-113

**Description**
Implements OAuth 2.0 Token Exchange (RFC 8693) support in the generic OAuth2 resource.

- New optional tokenExchangeEndpoint configuration (full URL, supports EL)
- OAuth2Resource#tokenExchange() implemented on the shared Vert.x HTTP client, so the resource's SSL, proxy and client authentication settings apply to the exchange call the same way they do for introspection
- Client authentication via Basic header (when useClientAuthorizationHeader is enabled) or client_id/client_secret form parameters
- WireMock tests covering both client auth modes, error responses and missing configuration

The first consumer will be the MCP Proxy token exchange upstream authentication (separate PRs in `gravitee-reactor-mcp-proxy / gravitee-gamma-module-aim`).

**Note**: depends on gravitee-resource-oauth2-provider-api 1.6.0 — the pinned 1.6.0-token-exchange-support-SNAPSHOT must be bumped to the released version before merge.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.1.0-aiam-113-token-exchange-support-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-oauth2-provider-generic/6.1.0-aiam-113-token-exchange-support-SNAPSHOT/gravitee-resource-oauth2-provider-generic-6.1.0-aiam-113-token-exchange-support-SNAPSHOT.zip)
  <!-- Version placeholder end -->
